### PR TITLE
readme.md: add an empty line to fix a link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 <img src="logo.png" width="640" alt=" ">
+
 An open source font implementing [pIqaD](https://www.evertype.com/standards/csur/klingon.html). A klingon writing system.
 
 ## Demo


### PR DESCRIPTION
GitHub's Markdown parser seems to be confused by a `<img>` tag immediately followed by a paragraph, which stops it from rendering the link to evertype.com properly. Add an empty line after `<img>` to fix the link.